### PR TITLE
Add basic shop and economy system

### DIFF
--- a/Assets/_Game/Scripts/Data/ShopItemData.cs
+++ b/Assets/_Game/Scripts/Data/ShopItemData.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+public enum ShopItemType { Crate, DepartmentUpgrade }
+
+[CreateAssetMenu(menuName = "Studio/Shop Item")]
+public class ShopItemData : ScriptableObject
+{
+    public string itemName;
+    public ShopItemType itemType;
+    public int price = 100;
+
+    [Header("Crate")]
+    public CrateData crate;
+
+    [Header("Upgrade")]
+    public DepartmentType upgradeDepartment;
+}

--- a/Assets/_Game/Scripts/Managers/EconomyManager.cs
+++ b/Assets/_Game/Scripts/Managers/EconomyManager.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+
+public class EconomyManager : MonoBehaviour
+{
+    public static EconomyManager Instance { get; private set; }
+
+    [Header("Starting Funds")]
+    public int startingMoney = 1000;
+
+    private int currentMoney;
+
+    public int CurrentMoney => currentMoney;
+
+    void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(this.gameObject);
+            return;
+        }
+        Instance = this;
+        currentMoney = startingMoney;
+    }
+
+    public bool Spend(int amount)
+    {
+        if (amount <= 0)
+            return true;
+
+        if (currentMoney < amount)
+        {
+            Debug.Log("Not enough funds.");
+            return false;
+        }
+
+        currentMoney -= amount;
+        return true;
+    }
+
+    public void Add(int amount)
+    {
+        if (amount > 0)
+            currentMoney += amount;
+    }
+}

--- a/Assets/_Game/Scripts/Managers/ShopManager.cs
+++ b/Assets/_Game/Scripts/Managers/ShopManager.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+
+public class ShopManager : MonoBehaviour
+{
+    [Header("Prefabs")]
+    public GameObject cratePrefab;
+
+    public void Purchase(ShopItemData item)
+    {
+        if (item == null)
+        {
+            Debug.LogWarning("Tried to purchase null item.");
+            return;
+        }
+
+        if (!EconomyManager.Instance.Spend(item.price))
+        {
+            Debug.Log("Purchase failed  not enough funds.");
+            return;
+        }
+
+        switch (item.itemType)
+        {
+            case ShopItemType.Crate:
+                GiveCrate(item.crate);
+                break;
+            case ShopItemType.DepartmentUpgrade:
+                UpgradeDepartment(item.upgradeDepartment);
+                break;
+        }
+    }
+
+    private void GiveCrate(CrateData crate)
+    {
+        if (crate == null)
+        {
+            Debug.LogWarning("Shop item missing crate reference.");
+            return;
+        }
+
+        if (cratePrefab == null)
+        {
+            Debug.LogError("Crate prefab reference not set on ShopManager.");
+            return;
+        }
+
+        var crateObj = Instantiate(cratePrefab, Vector3.zero, Quaternion.identity);
+        var spawner = crateObj.GetComponent<DepartmentCrateSpawner>();
+        if (spawner != null)
+        {
+            spawner.crateData = crate;
+            spawner.RefillCrate();
+        }
+    }
+
+    private void UpgradeDepartment(DepartmentType department)
+    {
+        Debug.Log($"Purchased upgrade for {department} department.");
+        // TODO: integrate with actual department upgrade system
+    }
+}


### PR DESCRIPTION
## Summary
- set up an `EconomyManager` singleton to track player funds
- add `ShopItemData` scriptable object for shop entries
- create a simple `ShopManager` that purchases crates or upgrades

## Testing
- `No tests specified.`

------
https://chatgpt.com/codex/tasks/task_e_683f5f98713c83218fc4032577f6f995