### PR TITLE
Add currency HUD and multi-currency support

### DIFF
--- a/Assets/_Game/Scripts/Data/ShopItemData.cs
+++ b/Assets/_Game/Scripts/Data/ShopItemData.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+public enum ShopItemType { Crate, DepartmentUpgrade }
+
+[CreateAssetMenu(menuName = "Studio/Shop Item")]
+public class ShopItemData : ScriptableObject
+{
+    public string itemName;
+    public ShopItemType itemType;
+    public int price = 100;
+
+    [Header("Crate")]
+    public CrateData crate;
+
+    [Header("Upgrade")]
+    public DepartmentType upgradeDepartment;
+}

--- a/Assets/_Game/Scripts/Managers/EconomyManager.cs
+++ b/Assets/_Game/Scripts/Managers/EconomyManager.cs
@@ -1,0 +1,70 @@
+using UnityEngine;
+
+using System.Collections.Generic;
+
+public enum CurrencyType { Money, Gems, Tickets }
+
+public class EconomyManager : MonoBehaviour
+{
+    public static EconomyManager Instance { get; private set; }
+
+    [Header("Starting Funds")]
+    public int startingMoney = 1000;
+    public int startingGems = 0;
+    public int startingTickets = 0;
+    private Dictionary<CurrencyType, int> currency = new();
+
+    public int CurrentMoney => GetAmount(CurrencyType.Money);
+
+    void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(this.gameObject);
+            return;
+        }
+        Instance = this;
+        currency[CurrencyType.Money] = startingMoney;
+        currency[CurrencyType.Gems] = startingGems;
+        currency[CurrencyType.Tickets] = startingTickets;
+    }
+
+    public bool Spend(CurrencyType type, int amount)
+    {
+        if (amount <= 0)
+            return true;
+
+        if (!currency.ContainsKey(type) || currency[type] < amount)
+        {
+            Debug.Log("Not enough funds.");
+            return false;
+        }
+
+        currency[type] -= amount;
+        OnCurrencyChanged(type);
+        return true;
+    }
+
+    public void Add(CurrencyType type, int amount)
+    {
+        if (amount <= 0)
+            return;
+
+        if (!currency.ContainsKey(type))
+            currency[type] = 0;
+
+        currency[type] += amount;
+        OnCurrencyChanged(type);
+    }
+
+    public int GetAmount(CurrencyType type)
+    {
+        return currency.TryGetValue(type, out int value) ? value : 0;
+    }
+
+    public System.Action<CurrencyType, int> CurrencyChanged;
+    private void OnCurrencyChanged(CurrencyType type)
+    {
+        CurrencyChanged?.Invoke(type, GetAmount(type));
+    }
+}

--- a/Assets/_Game/Scripts/Managers/ShopManager.cs
+++ b/Assets/_Game/Scripts/Managers/ShopManager.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+
+public class ShopManager : MonoBehaviour
+{
+    [Header("Prefabs")]
+    public GameObject cratePrefab;
+
+    public void Purchase(ShopItemData item)
+    {
+        if (item == null)
+        {
+            Debug.LogWarning("Tried to purchase null item.");
+            return;
+        }
+
+        if (!EconomyManager.Instance.Spend(CurrencyType.Money, item.price))
+        {
+            Debug.Log("Purchase failed  not enough funds.");
+            return;
+        }
+
+        switch (item.itemType)
+        {
+            case ShopItemType.Crate:
+                GiveCrate(item.crate);
+                break;
+            case ShopItemType.DepartmentUpgrade:
+                UpgradeDepartment(item.upgradeDepartment);
+                break;
+        }
+    }
+
+    private void GiveCrate(CrateData crate)
+    {
+        if (crate == null)
+        {
+            Debug.LogWarning("Shop item missing crate reference.");
+            return;
+        }
+
+        if (cratePrefab == null)
+        {
+            Debug.LogError("Crate prefab reference not set on ShopManager.");
+            return;
+        }
+
+        var crateObj = Instantiate(cratePrefab, Vector3.zero, Quaternion.identity);
+        var spawner = crateObj.GetComponent<DepartmentCrateSpawner>();
+        if (spawner != null)
+        {
+            spawner.crateData = crate;
+            spawner.RefillCrate();
+        }
+    }
+
+    private void UpgradeDepartment(DepartmentType department)
+    {
+        Debug.Log($"Purchased upgrade for {department} department.");
+        // TODO: integrate with actual department upgrade system
+    }
+}

--- a/Assets/_Game/Scripts/UI/CurrencyPanel.cs
+++ b/Assets/_Game/Scripts/UI/CurrencyPanel.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+using TMPro;
+
+public class CurrencyPanel : MonoBehaviour
+{
+    public TextMeshProUGUI moneyText;
+    public TextMeshProUGUI gemsText;
+    public TextMeshProUGUI ticketsText;
+
+    void Start()
+    {
+        UpdateAll();
+        if (EconomyManager.Instance != null)
+            EconomyManager.Instance.CurrencyChanged += OnCurrencyChanged;
+    }
+
+    void OnDestroy()
+    {
+        if (EconomyManager.Instance != null)
+            EconomyManager.Instance.CurrencyChanged -= OnCurrencyChanged;
+    }
+
+    private void OnCurrencyChanged(CurrencyType type, int amount)
+    {
+        switch (type)
+        {
+            case CurrencyType.Money:
+                if (moneyText != null) moneyText.text = amount.ToString();
+                break;
+            case CurrencyType.Gems:
+                if (gemsText != null) gemsText.text = amount.ToString();
+                break;
+            case CurrencyType.Tickets:
+                if (ticketsText != null) ticketsText.text = amount.ToString();
+                break;
+        }
+    }
+
+    private void UpdateAll()
+    {
+        if (EconomyManager.Instance == null)
+            return;
+
+        OnCurrencyChanged(CurrencyType.Money, EconomyManager.Instance.GetAmount(CurrencyType.Money));
+        OnCurrencyChanged(CurrencyType.Gems, EconomyManager.Instance.GetAmount(CurrencyType.Gems));
+        OnCurrencyChanged(CurrencyType.Tickets, EconomyManager.Instance.GetAmount(CurrencyType.Tickets));
+    }
+}

--- a/Assets/_Game/Scripts/UI/CurrencyPanel.cs.meta
+++ b/Assets/_Game/Scripts/UI/CurrencyPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # StudioHead-MergeGame
 My first Unity project.
+
+## Economy & Shop UI
+
+The `EconomyManager` now supports multiple currencies (`Money`, `Gems`, and `Tickets`).
+Attach the new `CurrencyPanel` prefab or script to a UI canvas and assign three
+`TextMeshProUGUI` fields to display these values. The panel listens for economy
+changes and updates automatically.


### PR DESCRIPTION
## Summary
- expand `EconomyManager` to track Money, Gems and Tickets
- adjust `ShopManager` to use the new money currency
- add `CurrencyPanel` UI script for displaying the three currencies
- update README with instructions for the currency panel

## Testing
- `grep -R "Test" -n | head`

------
https://chatgpt.com/codex/tasks/task_e_683f5f98713c83218fc4032577f6f995