### PR TITLE
Add full talent asset set

### DIFF
--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Action_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Action_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Action_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Action
+  role: 2
+  rarity: 3
+  genre: 0
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Action_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Action_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1850cc473fd40198fda271c478970a9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Animation_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Animation_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Animation_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Animation
+  role: 2
+  rarity: 3
+  genre: 11
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Animation_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Animation_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0016be878578495bacc1ee69bd53ffd2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Biography_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Biography_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Biography_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Biography
+  role: 2
+  rarity: 3
+  genre: 13
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Biography_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Biography_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 41ae09f2dd3448e190710e6e4c2787f9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Comedy_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Comedy_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Comedy_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Comedy
+  role: 2
+  rarity: 3
+  genre: 2
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Comedy_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Comedy_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 33fc991f31df4195ad07fcf53a299111
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Documentary_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Documentary_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Documentary_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Documentary
+  role: 2
+  rarity: 3
+  genre: 10
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Documentary_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Documentary_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9cf5b38f5bc346adbcce07243f706fe9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Drama_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Drama_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Drama_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Drama
+  role: 2
+  rarity: 3
+  genre: 1
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Drama_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Drama_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3382999a60594abbb98b93b4149df470
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Fantasy_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Fantasy_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Fantasy_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Fantasy
+  role: 2
+  rarity: 3
+  genre: 3
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Fantasy_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Fantasy_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 704dd13ec5674662851c4b31f0445127
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Horror_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Horror_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Horror_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Horror
+  role: 2
+  rarity: 3
+  genre: 4
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Horror_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Horror_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0cc04d1d90c247bbb8b3a9f442950d9b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Musical_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Musical_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Musical_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Musical
+  role: 2
+  rarity: 3
+  genre: 12
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Musical_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Musical_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6d867f21bc044bed969e49ecc5451260
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Mystery_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Mystery_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Mystery_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Mystery
+  role: 2
+  rarity: 3
+  genre: 5
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Mystery_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Mystery_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ea600dd04964100a8a793a128704a4f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Romance_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Romance_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Romance_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Romance
+  role: 2
+  rarity: 3
+  genre: 6
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Romance_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Romance_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b619591c09a464a884670e6b597fcf2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_SciFi_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_SciFi_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_SciFi_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor SciFi
+  role: 2
+  rarity: 3
+  genre: 8
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_SciFi_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_SciFi_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a658d97eed184c0c9ea7211016a0caea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Thriller_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Thriller_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Thriller_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Thriller
+  role: 2
+  rarity: 3
+  genre: 7
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Thriller_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Thriller_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cfb3237817a34781b910d517babf24d9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Western_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Western_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Actor_Western_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Actor Western
+  role: 2
+  rarity: 3
+  genre: 9
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Western_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Actors/Tal_Actor_Western_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 845ce60ef1e043428321d09fe7d5a73a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Action_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Action_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Action_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Action
+  role: 1
+  rarity: 3
+  genre: 0
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Action_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Action_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8cdc3cae27744fab865eee9596258f9a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Animation_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Animation_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Animation_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Animation
+  role: 1
+  rarity: 3
+  genre: 11
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Animation_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Animation_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 34937c038c39425eabed3c026ff8a9b0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Biography_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Biography_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Biography_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Biography
+  role: 1
+  rarity: 3
+  genre: 13
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Biography_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Biography_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aab70297032a4b33b241e593b9baf273
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Comedy_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Comedy_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Comedy_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Comedy
+  role: 1
+  rarity: 3
+  genre: 2
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Comedy_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Comedy_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fcc523aa236d4082ae3c2f95fac71c54
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Documentary_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Documentary_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Documentary_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Documentary
+  role: 1
+  rarity: 3
+  genre: 10
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Documentary_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Documentary_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 459f78b486f946bd881ae02c1d9bf2c9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Drama_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Drama_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Drama_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Drama
+  role: 1
+  rarity: 3
+  genre: 1
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Drama_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Drama_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3cdf11c349e546c8b05be71dff366e35
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Fantasy_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Fantasy_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Fantasy_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Fantasy
+  role: 1
+  rarity: 3
+  genre: 3
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Fantasy_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Fantasy_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 37fba20e309b43909d3aa69b53acda5b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Horror_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Horror_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Horror_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Horror
+  role: 1
+  rarity: 3
+  genre: 4
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Horror_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Horror_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7fb417223261479b8f9bc075499e0738
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Musical_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Musical_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Musical_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Musical
+  role: 1
+  rarity: 3
+  genre: 12
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Musical_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Musical_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80c085795f7045c791059ee19eea5b95
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Mystery_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Mystery_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Mystery_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Mystery
+  role: 1
+  rarity: 3
+  genre: 5
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Mystery_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Mystery_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc76041543084c36aace2d3504de56ed
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Romance_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Romance_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Romance_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Romance
+  role: 1
+  rarity: 3
+  genre: 6
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Romance_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Romance_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f9e8d8b3d4a24c1bb86bc64c79821a23
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_SciFi_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_SciFi_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_SciFi_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director SciFi
+  role: 1
+  rarity: 3
+  genre: 8
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_SciFi_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_SciFi_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db236ebf2b0a4e3b869c40d2012ceb27
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Thriller_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Thriller_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Thriller_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Thriller
+  role: 1
+  rarity: 3
+  genre: 7
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Thriller_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Thriller_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 641701d3a0f7414392f489a8b9b72b45
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Western_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Western_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Director_Western_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Director Western
+  role: 1
+  rarity: 3
+  genre: 9
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Western_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Directors/Tal_Director_Western_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1265937bd3ac46298ae901ac00b9b4dd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Animation_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Animation_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_Animation_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer Animation
+  role: 0
+  rarity: 3
+  genre: 11
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Animation_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Animation_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9a0c9d4fc96d45a99a14e95ba112127d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Biography_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Biography_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_Biography_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer Biography
+  role: 0
+  rarity: 3
+  genre: 13
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Biography_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Biography_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fbab1f53dcb44512862e7a9d746d59e4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Comedy_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Comedy_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_Comedy_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer Comedy
+  role: 0
+  rarity: 3
+  genre: 2
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Comedy_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Comedy_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e261f5f316548f6866cca4fb46fb89f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Documentary_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Documentary_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_Documentary_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer Documentary
+  role: 0
+  rarity: 3
+  genre: 10
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Documentary_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Documentary_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f8cea0f5d634e86900df70f97f463b6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Drama_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Drama_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_Drama_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer Drama
+  role: 0
+  rarity: 3
+  genre: 1
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Drama_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Drama_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a3320c8fe7b4e1785732e4e830cc900
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Fantasy_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Fantasy_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_Fantasy_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer Fantasy
+  role: 0
+  rarity: 3
+  genre: 3
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Fantasy_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Fantasy_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eaff7d316e8a431fb8061aeec0b8fa7d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Horror_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Horror_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_Horror_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer Horror
+  role: 0
+  rarity: 3
+  genre: 4
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Horror_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Horror_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eea93299e3eb4fbea70828de15566039
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Musical_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Musical_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_Musical_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer Musical
+  role: 0
+  rarity: 3
+  genre: 12
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Musical_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Musical_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: af7630d36b6e48e5aab73539801729f4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Mystery_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Mystery_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_Mystery_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer Mystery
+  role: 0
+  rarity: 3
+  genre: 5
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Mystery_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Mystery_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 283629296b00461a9a20d715f4fc53a4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Romance_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Romance_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_Romance_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer Romance
+  role: 0
+  rarity: 3
+  genre: 6
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Romance_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Romance_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 577a0b5c218447c4aa24ce55a089f099
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_SciFi_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_SciFi_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_SciFi_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer SciFi
+  role: 0
+  rarity: 3
+  genre: 8
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_SciFi_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_SciFi_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 44989bddf2774ccda8e75e304b473f2b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Thriller_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Thriller_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_Thriller_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer Thriller
+  role: 0
+  rarity: 3
+  genre: 7
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Thriller_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Thriller_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fa7e8b8bfd2749f1843c942284ad97c0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Western_D.asset
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Western_D.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 410bc44be1d8d4a429b0eaa99624d952, type: 3}
+  m_Name: Tal_Writer_Western_D
+  m_EditorClassIdentifier: Assembly-CSharp::TalentBaseData
+  talentName: Placeholder Writer Western
+  role: 0
+  rarity: 3
+  genre: 9
+  portrait: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Western_D.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Talent/Writers/Tal_Writer_Western_D.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a93584dd6ae24b73b70a2ee80e8f7ef6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add Writers, Directors and Actors subfolders
- create 14 placeholder assets for each talent role

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840ef3ba5248321a76b41220274e2fb