### PR TITLE
Add design log and update README

### DIFF
--- a/DESIGNLOG.md
+++ b/DESIGNLOG.md
@@ -1,0 +1,20 @@
+# Design Log
+
+This file tracks high level design choices and rationale for **Studio Head**, a top-down merge and idle prototype. Use this document to record major decisions so the team can reference past discussions and keep future work aligned.
+
+## Core Goals
+
+- **Merge Mechanics** – Allow players to drag items onto one another to create upgraded versions. The grid-based board manages space and prevents invalid placements.
+- **Modular Data** – Items are defined via `ScriptableObject` assets so designers can quickly add new props, costumes, or talent without touching code.
+- **Mobile Friendly** – Input handling supports both touch and mouse to keep the project cross-platform. The UI scales using Unity's Canvas Scaler.
+
+## Recent Decisions
+
+- **Economy System** – Added an `EconomyManager` that tracks multiple currencies (`Money`, `Gems`, `Tickets`). The `CurrencyPanel` listens for changes and updates the UI automatically.
+- **Color-Coded Tiers** – Merge items use background colors to represent tier level for quick readability. Tier 1 is gray and scales up to gold for tier 10.
+
+## Next Steps
+
+- Implement timed tile spawning to introduce new items over time.
+- Prototype the movie recipe system to combine merged items into short film projects.
+

--- a/README.md
+++ b/README.md
@@ -30,21 +30,20 @@ Built with **Unity 6.2 (2023 LTS)** and supports mobile-first platforms (iOS/And
 
 ## 📁 Project Structure
 
-StudioMerge-CoreStarter/
+StudioHead-MergeGame/
 ├── Assets/
-│   ├── _Game/
-│   │   ├── Scripts/
-│   │   ├── Prefabs/
-│   │   ├── Scenes/
-│   │   └── ScriptableObjects/
-│   ├── Docs/                ← 🧠 Design Logs, Diagrams, Goals
-│   └── Sprites/
-├── ProjectSettings/
+│   └── _Game/
+│       ├── Scripts/
+│       ├── Prefabs/
+│       ├── Scenes/
+│       └── ScriptableObjects/
+├── GeneratedAssets/
 ├── Packages/
+├── ProjectSettings/
 ├── README.md                ← 👋 Welcome doc for new contributors
 ├── DESIGNLOG.md             ← 📜 Running design decisions
 ├── .gitignore               ← 🧹 Prevent junk from polluting repo
-└── StudioMerge-CoreStarter.sln
+└── ignore.conf
 
 ---
 


### PR DESCRIPTION
## Summary
- document design decisions in `DESIGNLOG.md`
- sync README project structure with current repo layout

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840eecb2e208321b174ae65ed99148f