### PR TITLE
Replace MovieGenre with GenreType

### DIFF
--- a/Assets/_Game/Scripts/Data/TalentBaseData.cs
+++ b/Assets/_Game/Scripts/Data/TalentBaseData.cs
@@ -2,10 +2,6 @@ using UnityEngine;
 
 public enum TalentRole { Writer, Director, Actor }
 public enum TalentRarity { AList, BList, CList, DList }
-public enum MovieGenre {
-    Action, Drama, Comedy, Fantasy, Horror, Mystery, Romance,
-    Thriller, SciFi, Western, Documentary, Animation, Musical, Biography
-}
 
 [CreateAssetMenu(menuName = "Studio/Talent")]
 public class TalentBaseData : ScriptableObject
@@ -13,7 +9,7 @@ public class TalentBaseData : ScriptableObject
     public string talentName;
     public TalentRole role;
     public TalentRarity rarity;
-    public MovieGenre genre;
+    public GenreType genre;
     public Sprite portrait;
 
     public int MaxUses => rarity switch


### PR DESCRIPTION
## Summary
- replace outdated `MovieGenre` enum usage
- rely on the existing `GenreType` enum

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ef19d09483219a1054ffab6f88e6