### PR TITLE
Fix Shop spending API

### DIFF
--- a/Assets/_Game/Scripts/Managers/EconomyManager.cs
+++ b/Assets/_Game/Scripts/Managers/EconomyManager.cs
@@ -1,6 +1,4 @@
 using UnityEngine;
-
-
 using System.Collections.Generic;
 
 public enum CurrencyType { Money, Gems, Tickets }
@@ -13,49 +11,36 @@ public class EconomyManager : MonoBehaviour
     public int startingMoney = 1000;
     public int startingGems = 0;
     public int startingTickets = 0;
-    private Dictionary<CurrencyType, int> currency = new();
+
+    private readonly Dictionary<CurrencyType, int> currency = new();
 
     public int CurrentMoney => GetAmount(CurrencyType.Money);
-
-    private int currentMoney;
-
-    public int CurrentMoney => currentMoney;
 
     void Awake()
     {
         if (Instance != null && Instance != this)
         {
-            Destroy(this.gameObject);
+            Destroy(gameObject);
             return;
         }
+
         Instance = this;
-        
+
         currency[CurrencyType.Money] = startingMoney;
         currency[CurrencyType.Gems] = startingGems;
         currency[CurrencyType.Tickets] = startingTickets;
     }
 
     public bool Spend(CurrencyType type, int amount)
-
-        currentMoney = startingMoney;
-    }
-
-    public bool Spend(int amount)
-
     {
         if (amount <= 0)
             return true;
 
-
         if (!currency.ContainsKey(type) || currency[type] < amount)
-
-        if (currentMoney < amount)
-
         {
             Debug.Log("Not enough funds.");
             return false;
         }
-
 
         currency[type] -= amount;
         OnCurrencyChanged(type);
@@ -80,16 +65,9 @@ public class EconomyManager : MonoBehaviour
     }
 
     public System.Action<CurrencyType, int> CurrencyChanged;
+
     private void OnCurrencyChanged(CurrencyType type)
     {
         CurrencyChanged?.Invoke(type, GetAmount(type));
-        currentMoney -= amount;
-        return true;
-    }
-
-    public void Add(int amount)
-    {
-        if (amount > 0)
-            currentMoney += amount;
     }
 }

--- a/Assets/_Game/Scripts/Managers/ShopManager.cs
+++ b/Assets/_Game/Scripts/Managers/ShopManager.cs
@@ -14,9 +14,6 @@ public class ShopManager : MonoBehaviour
         }
 
         if (!EconomyManager.Instance.Spend(CurrencyType.Money, item.price))
-
-        if (!EconomyManager.Instance.Spend(item.price))
-
         {
             Debug.Log("Purchase failed  not enough funds.");
             return;


### PR DESCRIPTION
## Summary
- correct EconomyManager implementation after merge
- remove unused Spend overload and consolidate shop purchases

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840ef0881c0832185dbc4d8af510460