### PR TITLE
Expand department item tiers

### DIFF
--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T10.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T10.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Camera_T10
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
   department: 0
-  tier: 2
-  itemName: Camera T3
+  tier: 9
+  itemName: Camera T10
   icon: {fileID: 0}
   tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  nextTierItem: {fileID: 0}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T10.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0665f5f9f891468e80d61946e3558b92
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T4.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T4.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Camera_T4
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
   department: 0
-  tier: 2
-  itemName: Camera T3
+  tier: 3
+  itemName: Camera T4
   icon: {fileID: 0}
   tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  nextTierItem: {fileID: 11400000, guid: 49546e27f1144491b571c66a1d036f91, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T4.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe48949dc1a84d57b74799cf886cc102
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T5.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T5.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Camera_T5
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
   department: 0
-  tier: 2
-  itemName: Camera T3
+  tier: 4
+  itemName: Camera T5
   icon: {fileID: 0}
   tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  nextTierItem: {fileID: 11400000, guid: 1f3e96eeb61e4fc38c8d0c5e0b5346d0, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T5.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 49546e27f1144491b571c66a1d036f91
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T6.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T6.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Camera_T6
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
   department: 0
-  tier: 2
-  itemName: Camera T3
+  tier: 5
+  itemName: Camera T6
   icon: {fileID: 0}
   tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  nextTierItem: {fileID: 11400000, guid: 023bb54cbc06478e975f97cb6a480250, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T6.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f3e96eeb61e4fc38c8d0c5e0b5346d0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T7.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T7.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Camera_T7
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
   department: 0
-  tier: 2
-  itemName: Camera T3
+  tier: 6
+  itemName: Camera T7
   icon: {fileID: 0}
   tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  nextTierItem: {fileID: 11400000, guid: ab46a7243a014bc5b43c3d9298e6a70f, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T7.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 023bb54cbc06478e975f97cb6a480250
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T8.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T8.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Camera_T8
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
   department: 0
-  tier: 2
-  itemName: Camera T3
+  tier: 7
+  itemName: Camera T8
   icon: {fileID: 0}
   tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  nextTierItem: {fileID: 11400000, guid: 762eb0958e0747d8b245d2f63762b627, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T8.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ab46a7243a014bc5b43c3d9298e6a70f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T9.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T9.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Camera_T9
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
   department: 0
-  tier: 2
-  itemName: Camera T3
+  tier: 8
+  itemName: Camera T9
   icon: {fileID: 0}
   tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  nextTierItem: {fileID: 11400000, guid: 0665f5f9f891468e80d61946e3558b92, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T9.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Camera/Camera_T9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 762eb0958e0747d8b245d2f63762b627
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T10.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T10.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Sound_T10
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
-  department: 0
-  tier: 2
-  itemName: Camera T3
+  department: 1
+  tier: 9
+  itemName: Sound T10
   icon: {fileID: 0}
-  tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  tileColor: {r: 0.12222612, g: 0.15062083, b: 0.3773585, a: 1}
+  nextTierItem: {fileID: 0}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T10.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4766e0e09fe44126be45c17cb9a32b82
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T3.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T3.asset
@@ -17,5 +17,5 @@ MonoBehaviour:
   itemName: Sound T3
   icon: {fileID: 0}
   tileColor: {r: 0.12222612, g: 0.15062083, b: 0.3773585, a: 1}
-  nextTierItem: {fileID: 0}
+  nextTierItem: {fileID: 11400000, guid: f150add8251b434985be6bbb7c3441b1, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T4.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T4.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Sound_T4
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
-  department: 0
-  tier: 2
-  itemName: Camera T3
+  department: 1
+  tier: 3
+  itemName: Sound T4
   icon: {fileID: 0}
-  tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  tileColor: {r: 0.12222612, g: 0.15062083, b: 0.3773585, a: 1}
+  nextTierItem: {fileID: 11400000, guid: 5e2e495f64e34a22bfa38fcad99f7a3e, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T4.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f150add8251b434985be6bbb7c3441b1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T5.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T5.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Sound_T5
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
-  department: 0
-  tier: 2
-  itemName: Camera T3
+  department: 1
+  tier: 4
+  itemName: Sound T5
   icon: {fileID: 0}
-  tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  tileColor: {r: 0.12222612, g: 0.15062083, b: 0.3773585, a: 1}
+  nextTierItem: {fileID: 11400000, guid: 14829b663cb64c949e9485253818c61f, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T5.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e2e495f64e34a22bfa38fcad99f7a3e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T6.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T6.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Sound_T6
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
-  department: 0
-  tier: 2
-  itemName: Camera T3
+  department: 1
+  tier: 5
+  itemName: Sound T6
   icon: {fileID: 0}
-  tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  tileColor: {r: 0.12222612, g: 0.15062083, b: 0.3773585, a: 1}
+  nextTierItem: {fileID: 11400000, guid: 5dd4a178f00545b7834acaa277d16d90, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T6.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 14829b663cb64c949e9485253818c61f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T7.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T7.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Sound_T7
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
-  department: 0
-  tier: 2
-  itemName: Camera T3
+  department: 1
+  tier: 6
+  itemName: Sound T7
   icon: {fileID: 0}
-  tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  tileColor: {r: 0.12222612, g: 0.15062083, b: 0.3773585, a: 1}
+  nextTierItem: {fileID: 11400000, guid: c30cba992ee64757afda1f87b58480cc, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T7.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5dd4a178f00545b7834acaa277d16d90
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T8.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T8.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Sound_T8
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
-  department: 0
-  tier: 2
-  itemName: Camera T3
+  department: 1
+  tier: 7
+  itemName: Sound T8
   icon: {fileID: 0}
-  tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  tileColor: {r: 0.12222612, g: 0.15062083, b: 0.3773585, a: 1}
+  nextTierItem: {fileID: 11400000, guid: 53888777a97d40fcb655ab1fe20e236d, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T8.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c30cba992ee64757afda1f87b58480cc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T9.asset
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T9.asset
@@ -10,12 +10,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0266771888cafac4fbf6d3cc02c4f11e, type: 3}
-  m_Name: Camera_T3
+  m_Name: Sound_T9
   m_EditorClassIdentifier: Assembly-CSharp::DepartmentItemData
-  department: 0
-  tier: 2
-  itemName: Camera T3
+  department: 1
+  tier: 8
+  itemName: Sound T9
   icon: {fileID: 0}
-  tileColor: {r: 0.15876636, g: 0.23270428, b: 0.14123246, a: 1}
-  nextTierItem: {fileID: 11400000, guid: fe48949dc1a84d57b74799cf886cc102, type: 2}
+  tileColor: {r: 0.12222612, g: 0.15062083, b: 0.3773585, a: 1}
+  nextTierItem: {fileID: 11400000, guid: 4766e0e09fe44126be45c17cb9a32b82, type: 2}
   rewardMultiplier: 1

--- a/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T9.asset.meta
+++ b/Assets/_Game/ScriptableObjects/Department/Sound/Sound_T9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 53888777a97d40fcb655ab1fe20e236d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Game/Scripts/Data/DepartmentItemFactory.cs
+++ b/Assets/_Game/Scripts/Data/DepartmentItemFactory.cs
@@ -10,7 +10,7 @@ public static class DepartmentItemFactory
 
         // Filter for the desired department & tier
         var matchingItems = allItems
-            .Where(item => item.department == department && item.tier == DepartmentItemTier.Basic)
+            .Where(item => item.department == department && item.tier == DepartmentItemTier.Tier1)
             .ToList();
 
         if (matchingItems.Count == 0)

--- a/Assets/_Game/Scripts/Data/DepartmentItemTier.cs
+++ b/Assets/_Game/Scripts/Data/DepartmentItemTier.cs
@@ -2,7 +2,14 @@ using UnityEngine;
 
 public enum DepartmentItemTier
 {
-    Basic = 0,
-    Pro = 1,
-    Elite = 2
+    Tier1 = 0,
+    Tier2 = 1,
+    Tier3 = 2,
+    Tier4 = 3,
+    Tier5 = 4,
+    Tier6 = 5,
+    Tier7 = 6,
+    Tier8 = 7,
+    Tier9 = 8,
+    Tier10 = 9
 }

--- a/Assets/_Game/Scripts/Data/MovieRecipe.cs
+++ b/Assets/_Game/Scripts/Data/MovieRecipe.cs
@@ -11,7 +11,7 @@ public class MovieRecipe
     public List<DepartmentItemData> submittedItems = new();
 
     public int TotalItemTier =>
-        submittedItems.Sum(item => (int)item.tier + 1); // Basic = 1, Pro = 2, Elite = 3
+        submittedItems.Sum(item => (int)item.tier + 1); // Tier1 = 1 ... Tier10 = 10
 
     public bool HasAllRequiredDepartments()
     {

--- a/Assets/_Game/Scripts/Grid/GridItemView.cs
+++ b/Assets/_Game/Scripts/Grid/GridItemView.cs
@@ -33,13 +33,11 @@ public class GridItemView : MonoBehaviour
     /// </summary>
     private Color GetTierColor(DepartmentItemTier tier)
     {
-        return tier switch
-        {
-            DepartmentItemTier.Basic => new Color(0.8f, 0.8f, 0.8f), // Gray
-            DepartmentItemTier.Pro => new Color(0.3f, 0.6f, 1f),      // Blue
-            DepartmentItemTier.Elite => new Color(1f, 0.8f, 0.2f),    // Gold
-            _ => Color.white
-        };
+        // Simple gradient from gray (Tier1) to gold (Tier10)
+        var gray = new Color(0.8f, 0.8f, 0.8f);
+        var gold = new Color(1f, 0.8f, 0.2f);
+        float t = Mathf.Clamp01((int)tier / 9f);
+        return Color.Lerp(gray, gold, t);
     }
 
     public DepartmentItemData GetData()


### PR DESCRIPTION
## Summary
- update `DepartmentItemTier` to use Tier1-Tier10
- adjust `GridItemView` color method for 10 tiers
- search & replace Basic/Pro/Elite references
- comment tweak in `MovieRecipe`
- add department item data for tiers 4-10 for Camera & Sound

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841ffb924a4832180d61ff4afbc9323