### PR TITLE
Add streaming/festival/market distribution buttons

### DIFF
--- a/Assets/_Game/Scripts/UI/DistributionPanel.cs
+++ b/Assets/_Game/Scripts/UI/DistributionPanel.cs
@@ -10,6 +10,9 @@ public class DistributionPanel : MonoBehaviour
     public TextMeshProUGUI movieTitleText;
     public Button flatPayoutButton;
     public Button theatricalReleaseButton;
+    public Button streamingButton;
+    public Button festivalButton;
+    public Button filmMarketButton;
 
     private MovieRecipe currentRecipe;
 
@@ -18,7 +21,7 @@ public class DistributionPanel : MonoBehaviour
         currentRecipe = recipe;
         panelRoot.SetActive(true);
 
-        // Example text — customize with your actual recipe data
+        // Example text â€” customize with your actual recipe data
         movieTitleText.text = $" {GetMovieTitleFromRecipe(recipe)} is ready for distribution!";
         
         flatPayoutButton.onClick.RemoveAllListeners();
@@ -26,6 +29,18 @@ public class DistributionPanel : MonoBehaviour
 
         theatricalReleaseButton.onClick.RemoveAllListeners();
         theatricalReleaseButton.onClick.AddListener(() => HandleTheatricalRelease());
+
+        streamingButton.onClick.RemoveAllListeners();
+        streamingButton.onClick.AddListener(() => HandleStreamingRelease());
+        streamingButton.interactable = false;
+
+        festivalButton.onClick.RemoveAllListeners();
+        festivalButton.onClick.AddListener(() => HandleFestivalRelease());
+        festivalButton.interactable = false;
+
+        filmMarketButton.onClick.RemoveAllListeners();
+        filmMarketButton.onClick.AddListener(() => HandleFilmMarketRelease());
+        filmMarketButton.interactable = false;
     }
 
     private void HandleFlatPayout()
@@ -39,6 +54,24 @@ public class DistributionPanel : MonoBehaviour
     {
         Debug.Log(" Theatrical release selected!");
         // TODO: Start long-term release, tie to RCU system
+        ClosePanel();
+    }
+
+    private void HandleStreamingRelease()
+    {
+        Debug.Log(" Streaming release selected! (Not yet implemented)");
+        ClosePanel();
+    }
+
+    private void HandleFestivalRelease()
+    {
+        Debug.Log(" Festival distribution selected! (Not yet implemented)");
+        ClosePanel();
+    }
+
+    private void HandleFilmMarketRelease()
+    {
+        Debug.Log(" Film market distribution selected! (Not yet implemented)");
         ClosePanel();
     }
 

--- a/DESIGNLOG.md
+++ b/DESIGNLOG.md
@@ -18,6 +18,7 @@ This file tracks high level design choices and rationale for **Studio Head**, a 
 - **Shop Manager** – Added a `ShopManager` and expanded the multi-currency economy for in-game purchases.
 - **Talent Inventory** – Created `TalentInventory` and collectible talent cards.
 - **Crate Shop Panel** – Added buttons to buy a department crate that spawns on the grid and deducts currency.
+- **Distribution Options** – Added placeholder buttons for Streaming, Festival, and Film Market distribution types (currently disabled).
 
 ## Next Steps
 - Implement timed tile spawning to introduce new items over time.


### PR DESCRIPTION
## Summary
- add placeholder buttons for more distribution options
- document new options in `DESIGNLOG.md`

## Testing
- `npm test` *(fails: package.json missing)*
- `dotnet test` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684460e179788321b11842562402c1e8