### PR TITLE
Add item factory overload for crate spawns

### DIFF
--- a/Assets/_Game/Scripts/Data/DepartmentItemFactory.cs
+++ b/Assets/_Game/Scripts/Data/DepartmentItemFactory.cs
@@ -4,21 +4,31 @@ using System.Linq;
 
 public static class DepartmentItemFactory
 {
-    public static DepartmentItemData Create(DepartmentType department)
+    /// <summary>
+    /// Returns a random <see cref="DepartmentItemData"/> matching the given department and tier.
+    /// </summary>
+    public static DepartmentItemData Create(DepartmentType department, DepartmentItemTier tier)
     {
         var allItems = Resources.LoadAll<DepartmentItemData>("DepartmentItems");
 
-        // Filter for the desired department & tier
         var matchingItems = allItems
-            .Where(item => item.department == department && item.tier == DepartmentItemTier.Tier1)
+            .Where(item => item.department == department && item.tier == tier)
             .ToList();
 
         if (matchingItems.Count == 0)
         {
-            Debug.LogWarning($"No DepartmentItemData found for {department} in Resources/DepartmentItems");
+            Debug.LogWarning($"No DepartmentItemData found for {department} tier {tier} in Resources/DepartmentItems");
             return null;
         }
 
         return matchingItems[Random.Range(0, matchingItems.Count)];
+    }
+
+    /// <summary>
+    /// Convenience overload that always returns a tier 1 item for the department.
+    /// </summary>
+    public static DepartmentItemData Create(DepartmentType department)
+    {
+        return Create(department, DepartmentItemTier.Tier1);
     }
 }

--- a/Assets/_Game/Scripts/Managers/DepartmentCrateManager.cs
+++ b/Assets/_Game/Scripts/Managers/DepartmentCrateManager.cs
@@ -71,15 +71,7 @@ public class DepartmentCrateManager : MonoBehaviour
     DepartmentItemData GetRandomItem(Department dept)
     {
         DepartmentItemTier tier = GetWeightedTier(dept.dropWeights);
-        var allItems = Resources.LoadAll<DepartmentItemData>("DepartmentItems");
-        List<DepartmentItemData> matches = new();
-        foreach (var data in allItems)
-        {
-            if (data.department == dept.type && data.tier == tier)
-                matches.Add(data);
-        }
-        if (matches.Count == 0) return null;
-        return matches[Random.Range(0, matches.Count)];
+        return DepartmentItemFactory.Create(dept.type, tier);
     }
 
     DepartmentItemTier GetWeightedTier(List<Department.TierWeight> weights)


### PR DESCRIPTION
## Summary
- extend `DepartmentItemFactory` with tier-based item lookup
- replace manual Resources search in `DepartmentCrateManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847d05510bc83219a2f0e7a2a7e9415