### PR TITLE
Add dailies gating before distribution

### DIFF
--- a/Assets/_Game/Scripts/Managers/DailiesManager.cs
+++ b/Assets/_Game/Scripts/Managers/DailiesManager.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DailiesManager : MonoBehaviour
+{
+    [Header("References")]
+    public DistributionQueueManager distributionQueue;
+    public ProductionManager productionManager;
+
+    private class RecipeState
+    {
+        public int pendingAttempts;
+        public bool productionComplete;
+    }
+
+    private readonly Dictionary<MovieRecipe, RecipeState> recipeStates = new();
+
+    public void Initialize(ProductionManager manager)
+    {
+        if (productionManager != null)
+        {
+            productionManager.OnDailiesAvailable.RemoveListener(HandleDailiesAvailable);
+            productionManager.OnProductionCompleted.RemoveListener(HandleProductionCompleted);
+        }
+
+        productionManager = manager;
+
+        if (productionManager != null)
+        {
+            productionManager.OnDailiesAvailable.AddListener(HandleDailiesAvailable);
+            productionManager.OnProductionCompleted.AddListener(HandleProductionCompleted);
+        }
+    }
+
+    private void HandleDailiesAvailable(float milestone, MovieRecipe recipe)
+    {
+        if (!recipeStates.TryGetValue(recipe, out var state))
+            recipeStates[recipe] = state = new RecipeState();
+
+        state.pendingAttempts++;
+        Debug.Log($" Dailies milestone reached for recipe. Pending attempts: {state.pendingAttempts}");
+    }
+
+    private void HandleProductionCompleted(MovieRecipe recipe)
+    {
+        if (!recipeStates.TryGetValue(recipe, out var state))
+            recipeStates[recipe] = state = new RecipeState();
+
+        state.productionComplete = true;
+        Debug.Log(" Production complete. Waiting for all dailies attempts to finish.");
+        TryQueueRecipe(recipe, state);
+    }
+
+    public void PlayOrSkipDaily(MovieRecipe recipe)
+    {
+        if (!recipeStates.TryGetValue(recipe, out var state))
+            return;
+
+        if (state.pendingAttempts > 0)
+            state.pendingAttempts--;
+
+        Debug.Log($" Dailies attempt resolved. Remaining: {state.pendingAttempts}");
+        TryQueueRecipe(recipe, state);
+    }
+
+    private void TryQueueRecipe(MovieRecipe recipe, RecipeState state)
+    {
+        if (state.productionComplete && state.pendingAttempts == 0)
+        {
+            distributionQueue.QueueDistribution(recipe);
+            recipeStates.Remove(recipe);
+            Debug.Log(" All dailies handled. Movie queued for distribution.");
+        }
+    }
+}

--- a/Assets/_Game/Scripts/Managers/DailiesManager.cs.meta
+++ b/Assets/_Game/Scripts/Managers/DailiesManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8541584362ea48d48323369a0c50a198

--- a/Assets/_Game/Scripts/Managers/ProductionSystemLinker.cs
+++ b/Assets/_Game/Scripts/Managers/ProductionSystemLinker.cs
@@ -3,17 +3,11 @@ using UnityEngine;
 public class ProductionSystemLinker : MonoBehaviour
 {
     public ProductionManager productionManager;
-    public DistributionQueueManager distributionQueue;
+    public DailiesManager dailiesManager;
 
     void Start()
     {
-        // Register the callback so we know when a movie is done
-        productionManager.OnProductionCompleted.AddListener(HandleProductionComplete);
-    }
-
-    void HandleProductionComplete(MovieRecipe recipe)
-    {
-        Debug.Log(" Production complete! Forwarding movie to distribution queue.");
-        distributionQueue.QueueDistribution(recipe); //  The key line
+        if (dailiesManager != null)
+            dailiesManager.Initialize(productionManager);
     }
 }


### PR DESCRIPTION
## Summary
- add `DailiesManager` that waits for all dailies attempts
- hand off movie to `DistributionQueueManager` once dailies are done
- link `ProductionManager` and `DailiesManager` in `ProductionSystemLinker`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684825afe46083218090cbd3e571266f