### PR TITLE
Add overflow inventory panel UI

### DIFF
--- a/Assets/_Game/Scripts/Managers/InventoryOverflowManager.cs
+++ b/Assets/_Game/Scripts/Managers/InventoryOverflowManager.cs
@@ -14,6 +14,8 @@ public class InventoryOverflowManager : MonoBehaviour
 
     private InventoryOverflow overflow;
 
+    public System.Action OverflowUpdated;
+
     void Awake()
     {
         if (Instance != null && Instance != this)
@@ -33,12 +35,14 @@ public class InventoryOverflowManager : MonoBehaviour
 
     public int SlotsUsed => overflow.storedItems.Count;
     public int MaxSlots => overflow.currentSlots;
+    public IReadOnlyList<Item> StoredItems => overflow.storedItems;
 
     public bool AddItem(Item item)
     {
         if (overflow.CanStore(item))
         {
             overflow.Store(item);
+            OverflowUpdated?.Invoke();
             return true;
         }
         return false;
@@ -54,6 +58,7 @@ public class InventoryOverflowManager : MonoBehaviour
             return false;
 
         overflow.ExpandSlots(amount);
+        OverflowUpdated?.Invoke();
         return true;
     }
 

--- a/Assets/_Game/Scripts/UI/OverflowPanel.cs
+++ b/Assets/_Game/Scripts/UI/OverflowPanel.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+using TMPro;
+
+public class OverflowPanel : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+{
+    [Header("UI References")]
+    public RectTransform panelRoot;
+    public Button toggleButton;
+    public Transform itemGridParent;
+    public GameObject itemTilePrefab;
+    public TextMeshProUGUI slotLabel;
+
+    [Header("Slide Settings")]
+    public float collapsedY = -300f;
+    public float expandedY = 0f;
+    public float slideSpeed = 10f;
+
+    private bool isExpanded = false;
+    private Vector2 dragStart;
+    private Vector2 panelStart;
+
+    private void Awake()
+    {
+        if (toggleButton != null)
+            toggleButton.onClick.AddListener(Toggle);
+    }
+
+    private void Start()
+    {
+        if (panelRoot != null)
+            panelRoot.anchoredPosition = new Vector2(panelRoot.anchoredPosition.x, collapsedY);
+
+        RefreshUI();
+
+        if (InventoryOverflowManager.Instance != null)
+            InventoryOverflowManager.Instance.OverflowUpdated += OnOverflowChanged;
+    }
+
+    private void OnDestroy()
+    {
+        if (InventoryOverflowManager.Instance != null)
+            InventoryOverflowManager.Instance.OverflowUpdated -= OnOverflowChanged;
+    }
+
+    private void Update()
+    {
+        if (panelRoot == null)
+            return;
+        float target = isExpanded ? expandedY : collapsedY;
+        Vector2 pos = panelRoot.anchoredPosition;
+        pos.y = Mathf.Lerp(pos.y, target, Time.unscaledDeltaTime * slideSpeed);
+        panelRoot.anchoredPosition = pos;
+    }
+
+    public void Toggle()
+    {
+        isExpanded = !isExpanded;
+    }
+
+    public void OnBeginDrag(PointerEventData eventData)
+    {
+        if (panelRoot == null)
+            return;
+        dragStart = eventData.position;
+        panelStart = panelRoot.anchoredPosition;
+    }
+
+    public void OnDrag(PointerEventData eventData)
+    {
+        if (panelRoot == null)
+            return;
+        Vector2 delta = eventData.position - dragStart;
+        Vector2 pos = panelStart + new Vector2(0, delta.y);
+        pos.y = Mathf.Clamp(pos.y, collapsedY, expandedY);
+        panelRoot.anchoredPosition = pos;
+    }
+
+    public void OnEndDrag(PointerEventData eventData)
+    {
+        if (panelRoot == null)
+            return;
+        float midpoint = (collapsedY + expandedY) * 0.5f;
+        isExpanded = panelRoot.anchoredPosition.y > midpoint;
+    }
+
+    private void OnOverflowChanged()
+    {
+        RefreshUI();
+    }
+
+    private void RefreshUI()
+    {
+        RefreshItems();
+        UpdateSlotLabel();
+    }
+
+    private void RefreshItems()
+    {
+        if (itemGridParent == null || itemTilePrefab == null)
+            return;
+        foreach (Transform child in itemGridParent)
+            Destroy(child.gameObject);
+
+        var mgr = InventoryOverflowManager.Instance;
+        if (mgr == null)
+            return;
+
+        IReadOnlyList<Item> items = mgr.StoredItems;
+        foreach (var item in items)
+        {
+            GameObject go = Instantiate(itemTilePrefab, itemGridParent);
+            Image img = go.GetComponentInChildren<Image>();
+            if (img != null)
+                img.sprite = item.visual;
+        }
+    }
+
+    private void UpdateSlotLabel()
+    {
+        if (slotLabel == null)
+            return;
+        var mgr = InventoryOverflowManager.Instance;
+        if (mgr == null)
+            return;
+        slotLabel.text = $"{mgr.SlotsUsed}/{mgr.MaxSlots}";
+    }
+}

--- a/Assets/_Game/Scripts/UI/OverflowPanel.cs.meta
+++ b/Assets/_Game/Scripts/UI/OverflowPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46d36c7e489546b0be6c24b8582dff0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- expose overflow change events and stored item list
- implement `OverflowPanel` UI with slide toggle
- panel subscribes to `InventoryOverflowManager` to keep item grid and slot label updated

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6848660cc4e883219e10a9fd66c9a055