### PR TITLE
Update docs for main menu instructions

### DIFF
--- a/DESIGNLOG.md
+++ b/DESIGNLOG.md
@@ -19,12 +19,12 @@ This file tracks high level design choices and rationale for **Studio Head**, a 
 - **Talent Inventory** – Created `TalentInventory` and collectible talent cards.
 - **Crate Shop Panel** – Added buttons to buy a department crate that spawns on the grid and deducts currency.
 - **Distribution Options** – Added placeholder buttons for Streaming, Festival, and Film Market distribution types (currently disabled).
-- **CurrencyPanel integrated into HUD across top of screen.**
-- **Planned Main Menu scene with Settings overlay for initial navigation.**
 
 - **Inventory Overflow** – Items that exceed board capacity move to an overflow list. Players can purchase additional slots or clear space to reclaim them.
 - **Universal Crate Timer** – A single timer controls automatic crate spawns. Department type is chosen using weighted chances for varied drops.
 - **Genre Synergy Bonus** – Matching items grant a synergy percentage that boosts Money and Ticket rewards during distribution.
+- **CurrencyPanel integrated into HUD across top of screen.**
+- **Planned Main Menu scene with Settings overlay for initial navigation.**
 
 ## Next Steps
 - Finalize synergy bonus calculation and integrate with movie rewards.

--- a/README.md
+++ b/README.md
@@ -101,9 +101,8 @@ StudioHead-MergeGame/
 
 1. Clone this repo
 2. Open in Unity 6.2 or later
-3. Open `Scenes/MainMenu.unity`
-4. Hit Play and test drag + merge functionality.
-   The CurrencyPanel now appears across the top of the screen.
+3. Open `Scenes/MainMenu.unity` as your starting scene
+4. Hit Play to test drag + merge functionality. The CurrencyPanel now appears across the top of the screen.
 5. To add new items:
    - Create new `MergeItemData` ScriptableObject
    - Assign sprite, tier, and evolution


### PR DESCRIPTION
## Summary
- clarify Main Menu scene is the starting entry point
- move recent design decisions about the CurrencyPanel and planned Main Menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684866c03b0c8321a5b5231cc65d4a51