### PR TITLE
Add FilmArchiveManager and hook into distribution

### DIFF
--- a/Assets/_Game/Scripts/Data/MovieRecipe.cs
+++ b/Assets/_Game/Scripts/Data/MovieRecipe.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
+[System.Serializable]
+
 public class MovieRecipe
 {
     public TalentCard writer;

--- a/Assets/_Game/Scripts/Managers/DistributionQueueManager.cs
+++ b/Assets/_Game/Scripts/Managers/DistributionQueueManager.cs
@@ -8,6 +8,7 @@ public class DistributionQueueManager : MonoBehaviour
 
     private Queue<MovieRecipe> recipeQueue = new();
     private bool isPanelActive = false;
+    private MovieRecipe activeRecipe;
 
     /// <summary>
     /// Adds a movie recipe to the queue.
@@ -26,11 +27,11 @@ public class DistributionQueueManager : MonoBehaviour
         if (isPanelActive || recipeQueue.Count == 0)
             return;
 
-        var nextRecipe = recipeQueue.Dequeue();
+        activeRecipe = recipeQueue.Dequeue();
         isPanelActive = true;
 
         distributionPanel.OnDistributionComplete = HandlePanelClosed;
-        distributionPanel.OpenWithRecipe(nextRecipe);
+        distributionPanel.OpenWithRecipe(activeRecipe);
         distributionPanel.SetQueueCount(recipeQueue.Count); // Optional display
     }
 
@@ -40,6 +41,11 @@ public class DistributionQueueManager : MonoBehaviour
     private void HandlePanelClosed()
     {
         isPanelActive = false;
+
+        if (activeRecipe != null && FilmArchiveManager.Instance != null)
+            FilmArchiveManager.Instance.AddRecipe(activeRecipe);
+
+        activeRecipe = null;
         TryProcessNext();
     }
 }

--- a/Assets/_Game/Scripts/Managers/FilmArchiveManager.cs
+++ b/Assets/_Game/Scripts/Managers/FilmArchiveManager.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FilmArchiveManager : MonoBehaviour
+{
+    public static FilmArchiveManager Instance { get; private set; }
+
+    private readonly List<MovieRecipe> archivedRecipes = new();
+
+    [System.Serializable]
+    private class ArchiveWrapper
+    {
+        public List<MovieRecipe> recipes = new();
+    }
+
+    void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+        LoadArchive();
+    }
+
+    public IReadOnlyList<MovieRecipe> ArchivedRecipes => archivedRecipes;
+
+    public void AddRecipe(MovieRecipe recipe)
+    {
+        if (recipe == null)
+            return;
+
+        archivedRecipes.Add(recipe);
+        SaveArchive();
+    }
+
+    public void SaveArchive()
+    {
+        var wrapper = new ArchiveWrapper { recipes = archivedRecipes };
+        string json = JsonUtility.ToJson(wrapper);
+        PlayerPrefs.SetString("film_archive", json);
+        PlayerPrefs.Save();
+    }
+
+    public void LoadArchive()
+    {
+        archivedRecipes.Clear();
+
+        if (!PlayerPrefs.HasKey("film_archive"))
+            return;
+
+        string json = PlayerPrefs.GetString("film_archive");
+        var wrapper = JsonUtility.FromJson<ArchiveWrapper>(json);
+        if (wrapper != null && wrapper.recipes != null)
+            archivedRecipes.AddRange(wrapper.recipes);
+    }
+}

--- a/Assets/_Game/Scripts/Managers/FilmArchiveManager.cs.meta
+++ b/Assets/_Game/Scripts/Managers/FilmArchiveManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f9794673bcb44d38a7f1694d4e3ccae0


### PR DESCRIPTION
## Summary
- make `MovieRecipe` serializable
- add new `FilmArchiveManager` to store completed movie recipes with save/load
- forward completed recipes from `DistributionQueueManager` to the archive

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684867f39f5883219db5b96601952fc8