### PR TITLE
Implement overflow discard refund

### DIFF
--- a/Assets/_Game/Scripts/Data/DepartmentItemData.cs
+++ b/Assets/_Game/Scripts/Data/DepartmentItemData.cs
@@ -19,6 +19,9 @@ public class DepartmentItemData : ScriptableObject
     [Range(0f, 2f)]
     public float rewardMultiplier = 1f;
 
+    [Header("Economy")]
+    public int baseValue = 0;
+
     public bool IsRequired =>
         department == DepartmentType.Camera ||
         department == DepartmentType.Sound ||

--- a/Assets/_Game/Scripts/Data/InventoryOverflow.cs
+++ b/Assets/_Game/Scripts/Data/InventoryOverflow.cs
@@ -22,6 +22,14 @@ public class InventoryOverflow
         storedItems.Add(item);
     }
 
+    public bool Remove(Item item)
+    {
+        if (item == null)
+            return false;
+
+        return storedItems.Remove(item);
+    }
+
     public void ExpandSlots(int amount)
     {
         if (amount <= 0)

--- a/Assets/_Game/Scripts/Data/Item.cs
+++ b/Assets/_Game/Scripts/Data/Item.cs
@@ -6,6 +6,7 @@ public class Item
     public string departmentName;
     public int tier;
     public Sprite visual;
+    public int baseValue;
 
     public Item() { }
 
@@ -20,5 +21,6 @@ public class Item
         departmentName = data.department.ToString();
         tier = (int)data.tier;
         visual = data.icon;
+        baseValue = data.baseValue;
     }
 }

--- a/Assets/_Game/Scripts/Managers/InventoryOverflowManager.cs
+++ b/Assets/_Game/Scripts/Managers/InventoryOverflowManager.cs
@@ -48,6 +48,20 @@ public class InventoryOverflowManager : MonoBehaviour
         return false;
     }
 
+    public bool DiscardItem(Item item)
+    {
+        if (overflow.Remove(item))
+        {
+            int refund = Mathf.RoundToInt(item.baseValue * 0.1f);
+            if (EconomyManager.Instance != null && refund > 0)
+                EconomyManager.Instance.Add(CurrencyType.Money, refund);
+
+            OverflowUpdated?.Invoke();
+            return true;
+        }
+        return false;
+    }
+
     public bool PurchaseSlots(int amount)
     {
         if (amount <= 0)


### PR DESCRIPTION
## Summary
- add a `baseValue` to `DepartmentItemData`
- store item value in `Item`
- allow removing items from `InventoryOverflow`
- refund 10% of an item's baseValue when discarding it via `InventoryOverflowManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68486825dc808321ad8f7aa94d43a649