### PR TITLE
Add partial talent check before starting production

### DIFF
--- a/Assets/_Game/Scripts/Managers/ProductionManager.cs
+++ b/Assets/_Game/Scripts/Managers/ProductionManager.cs
@@ -32,6 +32,12 @@ public class ProductionManager : MonoBehaviour
             return;
         }
 
+        if (!recipeData.allowPartialTalent && recipe.TalentCount < 3)
+        {
+            Debug.LogWarning("All talent slots must be filled to start production.");
+            return;
+        }
+
         currentRecipe = recipe;
         isProducing = true;
 


### PR DESCRIPTION
## Summary
- ensure production requires all talents if partial talent setting disabled

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848698d72b88321b26272d7db35fc08