### PR TITLE
Add dailies tracking to MovieRecipe

### DIFF
--- a/Assets/_Game/Scripts/Data/MovieRecipe.cs
+++ b/Assets/_Game/Scripts/Data/MovieRecipe.cs
@@ -15,6 +15,10 @@ public class MovieRecipe
 
     public List<DepartmentItemData> submittedItems = new();
 
+    public int dailiesPlayed;
+    public float rewardMultiplier = 1.0f;
+    public List<int> dailyScores = new();
+
     public int TotalItemTier =>
         submittedItems.Sum(item => (int)item.tier + 1); // Tier1 = 1 ... Tier10 = 10
 

--- a/Assets/_Game/Scripts/Managers/DailiesManager.cs
+++ b/Assets/_Game/Scripts/Managers/DailiesManager.cs
@@ -51,13 +51,21 @@ public class DailiesManager : MonoBehaviour
         TryQueueRecipe(recipe, state);
     }
 
-    public void PlayOrSkipDaily(MovieRecipe recipe)
+    public void PlayOrSkipDaily(MovieRecipe recipe, int score = -1)
     {
         if (!recipeStates.TryGetValue(recipe, out var state))
             return;
 
         if (state.pendingAttempts > 0)
             state.pendingAttempts--;
+
+        recipe.dailiesPlayed++;
+
+        if (score >= 0)
+        {
+            recipe.dailyScores.Add(score);
+            recipe.rewardMultiplier += Mathf.Clamp01(score / 100f);
+        }
 
         Debug.Log($" Dailies attempt resolved. Remaining: {state.pendingAttempts}");
         TryQueueRecipe(recipe, state);

--- a/Assets/_Game/Scripts/Managers/ProductionManager.cs
+++ b/Assets/_Game/Scripts/Managers/ProductionManager.cs
@@ -90,7 +90,11 @@ public class ProductionManager : MonoBehaviour
 
         OnProductionCompleted?.Invoke(currentRecipe);
         if (RewardManager.Instance != null)
-            RewardManager.Instance.GrantRewards(currentRecipe.moneyReward, currentRecipe.fanReward);
+        {
+            int money = Mathf.RoundToInt(currentRecipe.moneyReward * currentRecipe.rewardMultiplier);
+            int fans = Mathf.RoundToInt(currentRecipe.fanReward * currentRecipe.rewardMultiplier);
+            RewardManager.Instance.GrantRewards(money, fans);
+        }
         UnlockTalents(currentRecipe);
         // Items are not unlocked; they are consumed
     }

--- a/Assets/_Game/Scripts/UI/DistributionPanel.cs
+++ b/Assets/_Game/Scripts/UI/DistributionPanel.cs
@@ -46,7 +46,12 @@ public class DistributionPanel : MonoBehaviour
     private void HandleFlatPayout()
     {
         Debug.Log(" Flat payout selected!");
-        // TODO: Give immediate money/fans rewards
+        if (RewardManager.Instance != null && currentRecipe != null)
+        {
+            int money = Mathf.RoundToInt(currentRecipe.moneyReward * currentRecipe.rewardMultiplier);
+            int fans = Mathf.RoundToInt(currentRecipe.fanReward * currentRecipe.rewardMultiplier);
+            RewardManager.Instance.GrantRewards(money, fans);
+        }
         ClosePanel();
     }
 


### PR DESCRIPTION
## Summary
- add fields to `MovieRecipe` for daily puzzle tracking and multipliers
- award rewards using `rewardMultiplier` in production and distribution
- record dailies play results in `DailiesManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684869d807c48321abcaf1861acc27e4