### PR TITLE
Add inventory overflow warnings

### DIFF
--- a/Assets/_Game/Scripts/Managers/InventoryOverflowManager.cs
+++ b/Assets/_Game/Scripts/Managers/InventoryOverflowManager.cs
@@ -14,6 +14,8 @@ public class InventoryOverflowManager : MonoBehaviour
     private InventoryOverflow overflow;
 
     public System.Action OverflowUpdated;
+    public System.Action<int> SlotsWarning;
+    public System.Action<int> ItemDiscarded;
 
     void Awake()
     {
@@ -42,8 +44,19 @@ public class InventoryOverflowManager : MonoBehaviour
         {
             overflow.Store(item);
             OverflowUpdated?.Invoke();
+
+            int remaining = overflow.currentSlots - overflow.storedItems.Count;
+            if (remaining < 3)
+                SlotsWarning?.Invoke(remaining);
+
             return true;
         }
+
+        int refund = Mathf.RoundToInt(item.baseValue * 0.1f);
+        if (EconomyManager.Instance != null && refund > 0)
+            EconomyManager.Instance.Add(CurrencyType.Money, refund);
+
+        ItemDiscarded?.Invoke(refund);
         return false;
     }
 

--- a/Assets/_Game/Scripts/UI/OverflowPanel.cs
+++ b/Assets/_Game/Scripts/UI/OverflowPanel.cs
@@ -13,6 +13,10 @@ public class OverflowPanel : MonoBehaviour, IBeginDragHandler, IDragHandler, IEn
     public GameObject itemTilePrefab;
     public TextMeshProUGUI slotLabel;
 
+    [Header("Feedback")] 
+    public TextMeshProUGUI warningText;
+    public TextMeshProUGUI refundText;
+
     [Header("Slide Settings")]
     public float collapsedY = -300f;
     public float expandedY = 0f;
@@ -35,14 +39,27 @@ public class OverflowPanel : MonoBehaviour, IBeginDragHandler, IDragHandler, IEn
 
         RefreshUI();
 
+        if (warningText != null)
+            warningText.text = string.Empty;
+        if (refundText != null)
+            refundText.text = string.Empty;
+
         if (InventoryOverflowManager.Instance != null)
+        {
             InventoryOverflowManager.Instance.OverflowUpdated += OnOverflowChanged;
+            InventoryOverflowManager.Instance.SlotsWarning += OnSlotsWarning;
+            InventoryOverflowManager.Instance.ItemDiscarded += OnItemDiscarded;
+        }
     }
 
     private void OnDestroy()
     {
         if (InventoryOverflowManager.Instance != null)
+        {
             InventoryOverflowManager.Instance.OverflowUpdated -= OnOverflowChanged;
+            InventoryOverflowManager.Instance.SlotsWarning -= OnSlotsWarning;
+            InventoryOverflowManager.Instance.ItemDiscarded -= OnItemDiscarded;
+        }
     }
 
     private void Update()
@@ -89,6 +106,18 @@ public class OverflowPanel : MonoBehaviour, IBeginDragHandler, IDragHandler, IEn
     private void OnOverflowChanged()
     {
         RefreshUI();
+    }
+
+    private void OnSlotsWarning(int remaining)
+    {
+        if (warningText != null)
+            warningText.text = $"Only {remaining} overflow slots remaining!";
+    }
+
+    private void OnItemDiscarded(int refund)
+    {
+        if (refundText != null)
+            refundText.text = $"Overflow full! Discarded item for {refund}";
     }
 
     private void RefreshUI()


### PR DESCRIPTION
## Summary
- raise events from `InventoryOverflowManager` when slots are nearly full or an item is discarded
- hook `OverflowPanel` to the new events
- display basic messages on the panel

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486bb5cc3c8321810ca3133b6e821a