### PR TITLE
Add basic Dailies puzzle setup

### DIFF
--- a/Assets/_Game/Scenes/DailiesPuzzle.unity
+++ b/Assets/_Game/Scenes/DailiesPuzzle.unity
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 0
+  m_Name: DailiesPuzzle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/_Game/Scenes/DailiesPuzzle.unity.meta
+++ b/Assets/_Game/Scenes/DailiesPuzzle.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 032b1d0a1a7c4b22a27a55d6e5294782
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/Scripts/Dailies.meta
+++ b/Assets/_Game/Scripts/Dailies.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ff8c1fb1bd6d4bef997a008c2d9fd72f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/Scripts/Dailies/DailiesBoardManager.cs
+++ b/Assets/_Game/Scripts/Dailies/DailiesBoardManager.cs
@@ -1,0 +1,194 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+/// <summary>
+/// Manages a small 4x4 merge board for the dailies mini game.
+/// </summary>
+public class DailiesBoardManager : MonoBehaviour
+{
+    [Header("References")]
+    public DailiesTile tilePrefab;
+    public DailiesConfig config;
+    public RectTransform boardRoot;
+    public TextMeshProUGUI budgetText;
+    public TextMeshProUGUI scoreText;
+    public Button skipButton;
+    public Button confirmButton;
+
+    public DailiesManager dailiesManager;
+    public MovieRecipe currentRecipe;
+
+    private DailiesTile[,] grid = new DailiesTile[4, 4];
+    private int remainingBudget;
+    private bool puzzleEnded;
+
+    private readonly List<DailiesTile> spawnBuffer = new();
+
+    void Start()
+    {
+        remainingBudget = config != null ? config.startingBudget : 100;
+        UpdateBudgetUI();
+        scoreText?.gameObject.SetActive(false);
+
+        skipButton?.onClick.AddListener(SkipPuzzle);
+        confirmButton?.onClick.AddListener(ConfirmPuzzle);
+        confirmButton?.gameObject.SetActive(false);
+
+        SpawnRandomTile();
+        SpawnRandomTile();
+    }
+
+    void Update()
+    {
+        if (puzzleEnded)
+            return;
+
+        if (Input.GetKeyDown(KeyCode.LeftArrow)) Move(Vector2Int.left);
+        if (Input.GetKeyDown(KeyCode.RightArrow)) Move(Vector2Int.right);
+        if (Input.GetKeyDown(KeyCode.UpArrow)) Move(Vector2Int.up);
+        if (Input.GetKeyDown(KeyCode.DownArrow)) Move(Vector2Int.down);
+    }
+
+    private void Move(Vector2Int dir)
+    {
+        bool moved = false;
+        bool[,] merged = new bool[4, 4];
+
+        var xs = dir.x > 0 ? new int[] { 3, 2, 1, 0 } : new int[] { 0, 1, 2, 3 };
+        var ys = dir.y > 0 ? new int[] { 3, 2, 1, 0 } : new int[] { 0, 1, 2, 3 };
+
+        foreach (int x in xs)
+        {
+            foreach (int y in ys)
+            {
+                var tile = grid[x, y];
+                if (tile == null) continue;
+
+                int nx = x;
+                int ny = y;
+                while (true)
+                {
+                    int tx = nx + dir.x;
+                    int ty = ny + dir.y;
+                    if (tx < 0 || tx >= 4 || ty < 0 || ty >= 4)
+                        break;
+                    if (grid[tx, ty] == null)
+                    {
+                        grid[tx, ty] = tile;
+                        grid[nx, ny] = null;
+                        nx = tx; ny = ty;
+                        moved = true;
+                        continue;
+                    }
+                    if (!merged[tx, ty] && grid[tx, ty].Level == tile.Level)
+                    {
+                        grid[tx, ty].Upgrade();
+                        Destroy(tile.gameObject);
+                        grid[nx, ny] = null;
+                        merged[tx, ty] = true;
+                        remainingBudget += config != null ? config.mergeSavings : 0;
+                        moved = true;
+                    }
+                    break;
+                }
+                if (tile != null)
+                {
+                    tile.transform.position = GetCellPosition(nx, ny);
+                }
+            }
+        }
+
+        if (moved)
+        {
+            remainingBudget -= config != null ? config.moveCost : 1;
+            SpawnRandomTile();
+            UpdateBudgetUI();
+            CheckEndConditions();
+        }
+    }
+
+    private void SpawnRandomTile()
+    {
+        var empty = new List<Vector2Int>();
+        for (int x = 0; x < 4; x++)
+            for (int y = 0; y < 4; y++)
+                if (grid[x, y] == null)
+                    empty.Add(new Vector2Int(x, y));
+
+        if (empty.Count == 0) return;
+
+        var cell = empty[Random.Range(0, empty.Count)];
+        var tile = Instantiate(tilePrefab, boardRoot);
+        tile.transform.localPosition = GetCellPosition(cell.x, cell.y);
+        tile.SetLevel(Random.value < 0.9f ? 1 : 2);
+        grid[cell.x, cell.y] = tile;
+        spawnBuffer.Add(tile);
+    }
+
+    private Vector3 GetCellPosition(int x, int y)
+    {
+        if (boardRoot == null) return Vector3.zero;
+        float size = boardRoot.rect.width / 4f;
+        return new Vector3((x + 0.5f) * size - boardRoot.rect.width / 2f,
+                           (y + 0.5f) * size - boardRoot.rect.height / 2f,
+                           0f);
+    }
+
+    private void UpdateBudgetUI()
+    {
+        if (budgetText != null)
+            budgetText.text = $"Budget: {remainingBudget}";
+    }
+
+    private void CheckEndConditions()
+    {
+        if (remainingBudget <= 0 || !CanMove())
+        {
+            EndPuzzle();
+        }
+    }
+
+    private bool CanMove()
+    {
+        for (int x = 0; x < 4; x++)
+        {
+            for (int y = 0; y < 4; y++)
+            {
+                var t = grid[x, y];
+                if (t == null) return true;
+                if (x < 3 && grid[x + 1, y] == null) return true;
+                if (y < 3 && grid[x, y + 1] == null) return true;
+                if (x < 3 && grid[x + 1, y] != null && grid[x + 1, y].Level == t.Level) return true;
+                if (y < 3 && grid[x, y + 1] != null && grid[x, y + 1].Level == t.Level) return true;
+            }
+        }
+        return false;
+    }
+
+    private int finalScore;
+    private void EndPuzzle()
+    {
+        puzzleEnded = true;
+        finalScore = Mathf.Max(0, remainingBudget);
+        confirmButton?.gameObject.SetActive(true);
+        if (scoreText != null)
+        {
+            scoreText.gameObject.SetActive(true);
+            scoreText.text = $"Score: {finalScore}";
+        }
+    }
+
+    private void SkipPuzzle()
+    {
+        if (dailiesManager != null && currentRecipe != null)
+            dailiesManager.PlayOrSkipDaily(currentRecipe, -1);
+    }
+
+    private void ConfirmPuzzle()
+    {
+        if (dailiesManager != null && currentRecipe != null)
+            dailiesManager.PlayOrSkipDaily(currentRecipe, finalScore);
+    }
+}

--- a/Assets/_Game/Scripts/Dailies/DailiesBoardManager.cs.meta
+++ b/Assets/_Game/Scripts/Dailies/DailiesBoardManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37c09a24bdef4540bb7f4a1a9eca0887
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/Scripts/Dailies/DailiesConfig.cs
+++ b/Assets/_Game/Scripts/Dailies/DailiesConfig.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+/// <summary>
+/// Configuration for the dailies mini puzzle.
+/// </summary>
+[CreateAssetMenu(menuName = "Dailies/Config", fileName = "DailiesConfig")]
+public class DailiesConfig : ScriptableObject
+{
+    [Header("Budget Settings")]
+    public int startingBudget = 100;
+    public int moveCost = 5;
+    public int mergeSavings = 3;
+
+    [Header("Scoring")]
+    public int baseScore = 100;
+}

--- a/Assets/_Game/Scripts/Dailies/DailiesConfig.cs.meta
+++ b/Assets/_Game/Scripts/Dailies/DailiesConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d79c648d8bae4ec8a5ae93c4b8c6be38
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/Scripts/Dailies/DailiesTile.cs
+++ b/Assets/_Game/Scripts/Dailies/DailiesTile.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+/// <summary>
+/// Represents a single tile in the Dailies puzzle grid.
+/// </summary>
+public class DailiesTile : MonoBehaviour
+{
+    public int Level { get; private set; } = 1;
+
+    /// <summary>
+    /// Apply a new level to this tile.
+    /// </summary>
+    public void SetLevel(int level)
+    {
+        Level = Mathf.Max(1, level);
+    }
+
+    /// <summary>
+    /// Upgrade this tile one level higher.
+    /// </summary>
+    public void Upgrade()
+    {
+        Level++;
+    }
+}

--- a/Assets/_Game/Scripts/Dailies/DailiesTile.cs.meta
+++ b/Assets/_Game/Scripts/Dailies/DailiesTile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4904bf38348543c79e2993c52444fe5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- create placeholder `DailiesPuzzle` scene
- introduce Dailies mini-game scripts and config
- implement board manager with simple 4x4 merge logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68486bc2d71c8321b4ce45a5338bb920