### PR TITLE
Add FranchiseManager and hook into production

### DIFF
--- a/Assets/_Game/Scripts/Managers/FranchiseManager.cs
+++ b/Assets/_Game/Scripts/Managers/FranchiseManager.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FranchiseManager : MonoBehaviour
+{
+    public static FranchiseManager Instance { get; private set; }
+
+    // Tracks how many films exist for each franchise title
+    private readonly Dictionary<string, int> franchiseCounts = new();
+
+    void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    /// <summary>
+    /// Registers a movie by title. If the title already exists,
+    /// it increments the sequel count.
+    /// </summary>
+    public void RegisterMovie(string title)
+    {
+        if (string.IsNullOrEmpty(title))
+            return;
+
+        if (franchiseCounts.ContainsKey(title))
+            franchiseCounts[title]++;
+        else
+            franchiseCounts[title] = 1;
+    }
+
+    /// <summary>
+    /// Returns how many movies are in the given franchise so far.
+    /// </summary>
+    public int GetSequelNumber(string title)
+    {
+        return franchiseCounts.TryGetValue(title, out int count) ? count : 0;
+    }
+}

--- a/Assets/_Game/Scripts/Managers/FranchiseManager.cs.meta
+++ b/Assets/_Game/Scripts/Managers/FranchiseManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f1b1e6f446e749d2a93f1f2270235597

--- a/Assets/_Game/Scripts/Managers/ProductionManager.cs
+++ b/Assets/_Game/Scripts/Managers/ProductionManager.cs
@@ -58,12 +58,17 @@ public class ProductionManager : MonoBehaviour
         recipe.moneyReward = Mathf.RoundToInt(recipeData.baseMoneyReward * (1f - recipeData.optionalDepartmentMoneyPenalty * missingOptional));
         recipe.fanReward = Mathf.RoundToInt(recipeData.baseFanReward * (1f - recipeData.optionalDepartmentFanPenalty * missingOptional));
 
-        if (recipeData.grantSynergyBonus && recipe.HasGenreSynergy() && recipeData.synergyBonusConfig != null)
+        if (recipeData.grantSynergyBonus && recipe.HasGenreSynergy())
         {
-            int highestTier = GetHighestTier(recipe);
-            float bonus = recipeData.synergyBonusConfig.GetBonusForTier(highestTier);
-            recipe.moneyReward = Mathf.RoundToInt(recipe.moneyReward * (1f + bonus));
-            recipe.fanReward = Mathf.RoundToInt(recipe.fanReward * (1f + bonus));
+            FranchiseManager.Instance?.RegisterMovie(recipeData.movieTitle);
+
+            if (recipeData.synergyBonusConfig != null)
+            {
+                int highestTier = GetHighestTier(recipe);
+                float bonus = recipeData.synergyBonusConfig.GetBonusForTier(highestTier);
+                recipe.moneyReward = Mathf.RoundToInt(recipe.moneyReward * (1f + bonus));
+                recipe.fanReward = Mathf.RoundToInt(recipe.fanReward * (1f + bonus));
+            }
         }
 
         LockResources(recipe);


### PR DESCRIPTION
## Summary
- add new **FranchiseManager** to track movie franchises and sequel counts
- start a franchise when production has a genre synergy
- keep manager persistent across scenes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68486df49324832184b6a104042a5f2a