### PR TITLE
Handle overflow storage when crate grid full

### DIFF
--- a/Assets/_Game/Scripts/Grid/DepartmentCrateSpawner.cs
+++ b/Assets/_Game/Scripts/Grid/DepartmentCrateSpawner.cs
@@ -55,6 +55,13 @@ public class DepartmentCrateSpawner : MonoBehaviour, IGridOccupant
             return;
         }
 
+        DepartmentItemData itemData = GetRandomItem();
+        if (itemData == null)
+        {
+            UnityEngine.Debug.LogError("Item spawn failed — itemData was null.");
+            return;
+        }
+
         Vector2Int? emptyCell = gridManager.GetRandomFreeCell();
 
         // Avoid spawning into the crate's own cell
@@ -66,16 +73,27 @@ public class DepartmentCrateSpawner : MonoBehaviour, IGridOccupant
             attempts++;
         }
 
-        if (emptyCell == null || emptyCell.Value == currentGridPos)
+        if (emptyCell == null)
         {
-            UnityEngine.Debug.LogWarning("No free grid cell available.");
+            var mgr = InventoryOverflowManager.Instance;
+            if (mgr != null)
+                mgr.Store(new Item(itemData));
+            else
+                UnityEngine.Debug.LogWarning("No free grid cell and OverflowManager missing.");
+
+            usesRemaining--;
+            UpdateVisuals();
+
+            if (usesRemaining == 0)
+            {
+                StartCoroutine(FadeAndDestroy());
+            }
             return;
         }
 
-        DepartmentItemData itemData = GetRandomItem();
-        if (itemData == null)
+        if (emptyCell.Value == currentGridPos)
         {
-            UnityEngine.Debug.LogError("Item spawn failed — itemData was null.");
+            UnityEngine.Debug.LogWarning("No free grid cell available.");
             return;
         }
 

--- a/Assets/_Game/Scripts/Managers/InventoryOverflowManager.cs
+++ b/Assets/_Game/Scripts/Managers/InventoryOverflowManager.cs
@@ -60,6 +60,14 @@ public class InventoryOverflowManager : MonoBehaviour
         return false;
     }
 
+    /// <summary>
+    /// Stores an item in the overflow without returning a result.
+    /// </summary>
+    public void Store(Item item)
+    {
+        AddItem(item);
+    }
+
     public bool DiscardItem(Item item)
     {
         if (overflow.Remove(item))


### PR DESCRIPTION
## Summary
- add `Store` helper to `InventoryOverflowManager`
- fallback to inventory overflow when no free grid cell exists in `DepartmentCrateSpawner`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68486e0baf2c83219f54508b846570c3