### PR TITLE
Add ScreeningRoom prefab and puzzle launching logic

### DIFF
--- a/Assets/_Game/Prefabs/Map/ScreeningRoom.prefab
+++ b/Assets/_Game/Prefabs/Map/ScreeningRoom.prefab
@@ -1,0 +1,135 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3}
+  m_Layer: 0
+  m_Name: ScreeningRoom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d68642c4ab0946b183c230d8d3f00553, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  puzzleButton: {fileID: 6}
+  dailiesManager: {fileID: 0}
+--- !u!1 &4
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5}
+  - component: {fileID: 6}
+  - component: {fileID: 7}
+  m_Layer: 5
+  m_Name: PuzzleButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.88235295, g: 0.88235295, b: 0.88235295, a: 1}
+    m_PressedColor: {r: 0.69803923, g: 0.69803923, b: 0.69803923, a: 1}
+    m_SelectedColor: {r: 0.88235295, g: 0.88235295, b: 0.88235295, a: 1}
+    m_DisabledColor: {r: 0.52156866, g: 0.52156866, b: 0.52156866, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_TargetGraphic: {fileID: 7}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &7
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_AlphaHitTestMinimumThreshold: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/_Game/Prefabs/Map/ScreeningRoom.prefab.meta
+++ b/Assets/_Game/Prefabs/Map/ScreeningRoom.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9aab1ecf874a421fa8c3d2fe951b5b0d
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Game/Scripts/Map/ScreeningRoom.cs
+++ b/Assets/_Game/Scripts/Map/ScreeningRoom.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Simple building that launches the dailies puzzle when a pending attempt is available.
+/// </summary>
+public class ScreeningRoom : MonoBehaviour
+{
+    [Header("References")]
+    public Button puzzleButton;
+    public DailiesManager dailiesManager;
+
+    void Awake()
+    {
+        if (puzzleButton != null)
+            puzzleButton.onClick.AddListener(HandleButton);
+    }
+
+    void Update()
+    {
+        if (puzzleButton != null)
+            puzzleButton.gameObject.SetActive(dailiesManager != null && dailiesManager.GetRecipeWithPendingDaily() != null);
+    }
+
+    private void HandleButton()
+    {
+        if (dailiesManager == null)
+            return;
+        MovieRecipe recipe = dailiesManager.GetRecipeWithPendingDaily();
+        if (recipe != null)
+            dailiesManager.LaunchPuzzle(recipe);
+    }
+}

--- a/Assets/_Game/Scripts/Map/ScreeningRoom.cs.meta
+++ b/Assets/_Game/Scripts/Map/ScreeningRoom.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d68642c4ab0946b183c230d8d3f00553


### PR DESCRIPTION
## Summary
- add ScreeningRoom MonoBehaviour to launch Dailies puzzle
- implement `DailiesManager.LaunchPuzzle` and helper method to find pending dailies
- create placeholder ScreeningRoom prefab with a button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68486e1e4f048321801da27a952095fc