### PR TITLE
Add drag-and-drop handling for movie recipe items

### DIFF
--- a/Assets/_Game/Scripts/UI/DepartmentItemDragUI.cs
+++ b/Assets/_Game/Scripts/UI/DepartmentItemDragUI.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class DepartmentItemDragUI : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+{
+    public DepartmentItemData itemData;
+
+    private CanvasGroup canvasGroup;
+    private Transform originalParent;
+
+    public DepartmentItemData ItemData => itemData;
+
+    private void Awake()
+    {
+        canvasGroup = GetComponent<CanvasGroup>();
+        if (canvasGroup == null)
+            canvasGroup = gameObject.AddComponent<CanvasGroup>();
+    }
+
+    public void OnBeginDrag(PointerEventData eventData)
+    {
+        originalParent = transform.parent;
+        transform.SetParent(transform.root, false);
+        canvasGroup.blocksRaycasts = false;
+    }
+
+    public void OnDrag(PointerEventData eventData)
+    {
+        transform.position = eventData.position;
+    }
+
+    public void OnEndDrag(PointerEventData eventData)
+    {
+        transform.SetParent(originalParent, false);
+        canvasGroup.blocksRaycasts = true;
+    }
+
+    /// <summary>
+    /// Optional helper when the dragged item is consumed by a drop target.
+    /// </summary>
+    public void Consume()
+    {
+        Destroy(gameObject);
+    }
+}

--- a/Assets/_Game/Scripts/UI/MovieRecipeItemSlotUI.cs
+++ b/Assets/_Game/Scripts/UI/MovieRecipeItemSlotUI.cs
@@ -1,7 +1,8 @@
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 
-public class MovieRecipeItemSlotUI : MonoBehaviour
+public class MovieRecipeItemSlotUI : MonoBehaviour, IDropHandler, IPointerClickHandler
 {
     public Image iconImage;
 
@@ -20,6 +21,42 @@ public class MovieRecipeItemSlotUI : MonoBehaviour
         AssignedItem = item;
         if (iconImage != null)
             iconImage.sprite = item != null ? item.icon : DepartmentItemLibraryInstance.GetIcon(Department);
+    }
+
+    public void OnDrop(PointerEventData eventData)
+    {
+        if (eventData.pointerDrag == null)
+            return;
+
+        var dragUI = eventData.pointerDrag.GetComponent<DepartmentItemDragUI>();
+        if (dragUI == null)
+            return;
+
+        SetItem(dragUI.ItemData);
+        dragUI.Consume();
+    }
+
+    public void OnPointerClick(PointerEventData eventData)
+    {
+        if (eventData.button != PointerEventData.InputButton.Right)
+            return;
+
+        ReturnItemToInventory();
+    }
+
+    /// <summary>
+    /// Returns the assigned item back to the overflow inventory and clears the slot.
+    /// </summary>
+    public void ReturnItemToInventory()
+    {
+        if (AssignedItem == null)
+            return;
+
+        var mgr = InventoryOverflowManager.Instance;
+        if (mgr != null)
+            mgr.Store(new Item(AssignedItem));
+
+        ClearItem();
     }
 
     public void ClearItem()


### PR DESCRIPTION
## Summary
- create `DepartmentItemDragUI` for draggable DepartmentItemData icons
- allow `MovieRecipeItemSlotUI` to accept dropped items and remove them from the drag source
- right-clicking a slot returns its item back to the overflow inventory

## Testing
- `dotnet test` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848977ec380832187ade26ec74c6e25