### PR TITLE
Add dailies results panel

### DIFF
--- a/Assets/_Game/Prefabs/UI/DailiesResultsPanel.prefab
+++ b/Assets/_Game/Prefabs/UI/DailiesResultsPanel.prefab
@@ -1,0 +1,49 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3}
+  m_Layer: 5
+  m_Name: DailiesResultsPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48a96887ad9b4d08b15af24f427f9368, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  panelRoot: {fileID: 1}
+  budgetText: {fileID: 0}
+  multiplierText: {fileID: 0}
+  continueButton: {fileID: 0}

--- a/Assets/_Game/Prefabs/UI/DailiesResultsPanel.prefab.meta
+++ b/Assets/_Game/Prefabs/UI/DailiesResultsPanel.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 19f2367b029d46d494ebce3d5a55065b
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  defaultTexture: {fileID: 0}

--- a/Assets/_Game/Scripts/Dailies/DailiesBoardManager.cs
+++ b/Assets/_Game/Scripts/Dailies/DailiesBoardManager.cs
@@ -15,7 +15,7 @@ public class DailiesBoardManager : MonoBehaviour
     public TextMeshProUGUI budgetText;
     public TextMeshProUGUI scoreText;
     public Button skipButton;
-    public Button confirmButton;
+    public DailiesResultsPanel resultsPanel;
 
     public DailiesManager dailiesManager;
     public MovieRecipe currentRecipe;
@@ -33,8 +33,6 @@ public class DailiesBoardManager : MonoBehaviour
         scoreText?.gameObject.SetActive(false);
 
         skipButton?.onClick.AddListener(SkipPuzzle);
-        confirmButton?.onClick.AddListener(ConfirmPuzzle);
-        confirmButton?.gameObject.SetActive(false);
 
         SpawnRandomTile();
         SpawnRandomTile();
@@ -172,8 +170,12 @@ public class DailiesBoardManager : MonoBehaviour
     {
         puzzleEnded = true;
         finalScore = Mathf.Max(0, remainingBudget);
-        confirmButton?.gameObject.SetActive(true);
-        if (scoreText != null)
+        float multiplier = 0f;
+        if (config != null)
+            multiplier = Mathf.Clamp01(finalScore / (float)config.baseScore);
+        if (resultsPanel != null)
+            resultsPanel.Show(finalScore, multiplier, ConfirmPuzzle);
+        else if (scoreText != null)
         {
             scoreText.gameObject.SetActive(true);
             scoreText.text = $"Score: {finalScore}";

--- a/Assets/_Game/Scripts/UI/DailiesResultsPanel.cs
+++ b/Assets/_Game/Scripts/UI/DailiesResultsPanel.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using UnityEngine.Events;
+
+public class DailiesResultsPanel : MonoBehaviour
+{
+    [Header("UI References")]
+    public GameObject panelRoot;
+    public TextMeshProUGUI budgetText;
+    public TextMeshProUGUI multiplierText;
+    public Button continueButton;
+
+    private UnityAction onContinue;
+
+    private void Awake()
+    {
+        if (continueButton != null)
+            continueButton.onClick.AddListener(HandleContinue);
+        if (panelRoot != null)
+            panelRoot.SetActive(false);
+    }
+
+    public void Show(int remainingBudget, float multiplier, UnityAction onContinueAction)
+    {
+        onContinue = onContinueAction;
+        if (budgetText != null)
+            budgetText.text = $"Budget Left: {remainingBudget}";
+        if (multiplierText != null)
+            multiplierText.text = $"Multiplier +{multiplier:0.##}";
+        if (panelRoot != null)
+            panelRoot.SetActive(true);
+    }
+
+    private void HandleContinue()
+    {
+        if (panelRoot != null)
+            panelRoot.SetActive(false);
+        onContinue?.Invoke();
+    }
+}

--- a/Assets/_Game/Scripts/UI/DailiesResultsPanel.cs.meta
+++ b/Assets/_Game/Scripts/UI/DailiesResultsPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48a96887ad9b4d08b15af24f427f9368
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- show dailies results through new `DailiesResultsPanel`
- hook `DailiesBoardManager` to open the panel and report results

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848990dcc548321a4983bf537f8707f