### PR TITLE
Add reward multiplier tracking to ProductionManager

### DIFF
--- a/Assets/_Game/Scripts/Managers/ProductionManager.cs
+++ b/Assets/_Game/Scripts/Managers/ProductionManager.cs
@@ -39,6 +39,15 @@ public class ProductionManager : MonoBehaviour
         }
 
         currentRecipe = recipe;
+
+        // base multiplier from submitted department items
+        float itemMultiplier = 1f;
+        if (recipe.submittedItems != null)
+        {
+            foreach (var item in recipe.submittedItems)
+                itemMultiplier *= item.rewardMultiplier;
+        }
+        recipe.rewardMultiplier = itemMultiplier;
         isProducing = true;
 
         int missingOptional = 0;


### PR DESCRIPTION
## Summary
- compute item-based reward multiplier when production starts
- store multiplier on `MovieRecipe` so distribution rewards scale accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848f79728c08321ab502b804efd7f20